### PR TITLE
fix: Only log write requests to /anmeldungs

### DIFF
--- a/backend/middlewares/requestsLogger/index.js
+++ b/backend/middlewares/requestsLogger/index.js
@@ -4,7 +4,7 @@ module.exports = strapi => {
       strapi.app.use(async (ctx, next) => {
         await next();
         const { url, method, body } = ctx.request
-        if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+        if(url === /anmeldungs/ && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
           strapi.log.debug(method, url, body)
         }
       });


### PR DESCRIPTION
We don't want to write our admin passwords to the logs!