### PR TITLE
fix: missing vuetify-stylesheet in dynamic routes

### DIFF
--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -151,23 +151,4 @@ export default {
   build: {
     transpile: ['mapbox-gl-controls/lib/styles'],
   },
-
-  generate: {
-    async routes() {
-      let { data: veranstaltungen } = await axios.get(
-        `${apiUrl}/veranstaltungs`,
-        {
-          params: {
-            _sort: 'Datum:ASC',
-            Datum_gte: new Date(),
-          },
-        }
-      )
-      veranstaltungen = veranstaltungen.map((veranstaltung) => {
-        return '/veranstaltung/' + veranstaltung.id
-      })
-
-      return veranstaltungen
-    },
-  },
 }


### PR DESCRIPTION
I have a similar problem but on dynamic routes: https://github.com/nuxt-community/vuetify-module/issues/91

Fixed by try+error, I have no idea why this bug occurred.